### PR TITLE
fix: populate grid column with 0 when features don't overlap AOI

### DIFF
--- a/geest/core/grid_column_utils.py
+++ b/geest/core/grid_column_utils.py
@@ -957,6 +957,57 @@ def clear_grid_column(gpkg_path: str, column_name: str) -> bool:
         return False
 
 
+def fill_grid_column_zero_for_area(
+    gpkg_path: str,
+    column_name: str,
+    area_name: str,
+) -> bool:
+    """Set all NULL values to 0 in a grid column for a specific area.
+
+    Used when a workflow produces no features for an area (e.g. OSM points
+    outside the AOI).  Score 0 ("not enabling") is a meaningful result and
+    must be persisted so the grid renders correctly instead of showing
+    transparent/nodata cells.
+
+    Args:
+        gpkg_path: Path to the GeoPackage containing study_area_grid.
+        column_name: Name of the column to fill.
+        area_name: The area_name value identifying which cells to update.
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    if not os.path.exists(gpkg_path):
+        log_message(f"GeoPackage not found: {gpkg_path}", level=Qgis.Warning)
+        return False
+
+    sanitized_column = _sanitize_column_name(column_name)
+
+    try:
+        ds = _open_gpkg_for_write(gpkg_path)
+        if not ds:
+            log_message(f"Could not open GeoPackage for write: {gpkg_path}", level=Qgis.Critical)
+            return False
+
+        sql = (
+            f'UPDATE study_area_grid SET "{sanitized_column}" = 0 '  # nosec B608
+            f"WHERE area_name = '{area_name}' AND \"{sanitized_column}\" IS NULL"
+        )
+        _execute_sql_with_retry(ds, sql)
+        ds = None
+        log_message(
+            f"Set score 0 for NULL cells in column {sanitized_column} for area {area_name}",
+        )
+        return True
+
+    except Exception as e:
+        log_message(
+            f"Error filling grid column zero for area: {e}",
+            level=Qgis.Critical,
+        )
+        return False
+
+
 def count_features_per_grid_cell(
     gpkg_path: str,
     column_name: str,

--- a/geest/core/workflows/workflow_base.py
+++ b/geest/core/workflows/workflow_base.py
@@ -40,6 +40,8 @@ from geest.core.algorithms import (
 )
 from geest.core.constants import GDAL_OUTPUT_DATA_TYPE
 from geest.core.grid_column_utils import (
+    clear_grid_column,
+    fill_grid_column_zero_for_area,
     rasterize_grid_column,
     write_raster_values_to_grid,
 )
@@ -157,6 +159,8 @@ class WorkflowBase(QObject):
         self.analysis_mode = self.item.attribute("analysis_mode", "")
         # Grid-first mode: if True, skip raster-to-grid sampling since grid is already populated
         self.use_grid_first = False
+        # Track if grid column has been cleared (for fallback paths that skip _process_grid_first)
+        self._grid_column_cleared = False
         self.updateProgress(0.0)
         self.output_filename = self.attributes.get("output_filename", "")
         self.feedback.progressChanged.connect(self.updateProgress)
@@ -651,6 +655,8 @@ class WorkflowBase(QObject):
                                     index=index,
                                     area_name=area_name,
                                 )
+                                if self.use_grid_first and area_name:
+                                    self._apply_grid_column_zero_fallback(area_name)
                                 if not raster_output:
                                     log_message(
                                         f"Neutral fallback failed for {self.workflow_name} in area {area_name}; skipping area.",
@@ -710,6 +716,8 @@ class WorkflowBase(QObject):
                             index=index,
                             area_name=area_name,
                         )
+                        if self.use_grid_first and area_name:
+                            self._apply_grid_column_zero_fallback(area_name)
                     if not raster_output:
                         raise RuntimeError(
                             f"{self.workflow_name} produced no raster output for area {area_name} (index {index})."
@@ -835,6 +843,25 @@ class WorkflowBase(QObject):
                 level=Qgis.Warning,
             )
             return None
+
+    def _apply_grid_column_zero_fallback(self, area_name: str) -> None:
+        """Fill grid column with 0 for an area when no features are present.
+
+        Called from neutral fallback paths when use_grid_first is True.
+        Clears the column once per workflow run, then sets 0 for the area's cells.
+
+        Args:
+            area_name: The area_name identifying which grid cells to update.
+        """
+        if not self._grid_column_cleared:
+            clear_grid_column(self.gpkg_path, self.layer_id)
+            self._grid_column_cleared = True
+
+        fill_grid_column_zero_for_area(
+            gpkg_path=self.gpkg_path,
+            column_name=self.layer_id,
+            area_name=area_name,
+        )
 
     def _create_workflow_directory(self) -> str:
         """


### PR DESCRIPTION
Issue: Grid-first workflows skipped grid column updates when the neutral fallback triggered (no features in area), leaving cells NULL instead of score 0.


https://github.com/user-attachments/assets/02cc09b8-9c42-433a-870c-2a1fe7b1a15b

Fix:

<img width="1583" height="727" alt="Screenshot From 2026-07-14 20-21-48" src="https://github.com/user-attachments/assets/093a7e28-0939-4c20-8397-d0326dae6c6d" />
