### PR TITLE
fix(ui): detached document opening and survivable routing-panel Next

### DIFF
--- a/geest/core/tasks/analysis_report_task.py
+++ b/geest/core/tasks/analysis_report_task.py
@@ -5,13 +5,11 @@ This module contains the QgsTask for generating analysis reports in the backgrou
 """
 
 import os
-import platform
-import subprocess  # nosec B404
 
 from qgis.core import Qgis, QgsTask
 
 from geest.core.reports.analysis_report import AnalysisReport
-from geest.utilities import log_message
+from geest.utilities import log_message, open_with_system_handler
 
 
 class AnalysisReportTask(QgsTask):
@@ -72,18 +70,9 @@ class AnalysisReportTask(QgsTask):
             result: True if task succeeded, False otherwise.
         """
         if result:
-            try:
-                # Open the PDF using the system PDF viewer
-                if os.name == "nt":  # Windows
-                    os.startfile(self.pdf_path)  # nosec B606
-                else:  # macOS and Linux
-                    system = platform.system().lower()
-                    if system == "darwin":  # macOS
-                        subprocess.run(["open", self.pdf_path], check=False)  # nosec B603 B607
-                    else:  # Linux
-                        subprocess.run(["xdg-open", self.pdf_path], check=False)  # nosec B603 B607
-            except Exception as e:
-                log_message(f"Could not open PDF viewer: {e}", tag="GeoE3", level=Qgis.Warning)
+            # Open the PDF using the system PDF viewer (detached — this
+            # runs on the main thread and must not block the event loop).
+            open_with_system_handler(self.pdf_path)
         else:
             log_message("Analysis report generation failed.", tag="GeoE3", level=Qgis.Critical)
 

--- a/geest/core/tasks/study_area_report_task.py
+++ b/geest/core/tasks/study_area_report_task.py
@@ -5,13 +5,11 @@ This module contains the QgsTask for generating study area reports in the backgr
 """
 
 import os
-import platform
-import subprocess  # nosec B404
 
 from qgis.core import Qgis, QgsTask
 
 from geest.core.reports.study_area_report import StudyAreaReport
-from geest.utilities import log_message
+from geest.utilities import log_message, open_with_system_handler
 
 
 class StudyAreaReportTask(QgsTask):
@@ -62,17 +60,9 @@ class StudyAreaReportTask(QgsTask):
             result: True if task succeeded, False otherwise.
         """
         if result:
-            try:
-                if os.name == "nt":
-                    os.startfile(self.report_path)  # nosec B606
-                else:
-                    system = platform.system().lower()
-                    if system == "darwin":
-                        subprocess.run(["open", self.report_path], check=False)  # nosec B603 B607
-                    else:
-                        subprocess.run(["xdg-open", self.report_path], check=False)  # nosec B603 B607
-            except Exception as e:
-                log_message(f"Could not open PDF viewer: {e}", tag="GeoE3", level=Qgis.Warning)
+            # Open the PDF using the system PDF viewer (detached — this
+            # runs on the main thread and must not block the event loop).
+            open_with_system_handler(self.report_path)
         else:
             log_message("Study area report generation failed.", tag="GeoE3", level=Qgis.Critical)
 

--- a/geest/gui/geoe3_dock.py
+++ b/geest/gui/geoe3_dock.py
@@ -469,21 +469,34 @@ class GeoE3Dock(QDockWidget):
             log_message("Switched to Help panel")
 
     def _open_road_network_from_ors(self) -> None:
-        """Open the road network panel from ORS with a valid working directory."""
+        """Open the road network panel from ORS with a valid working directory.
+
+        This runs as a signal slot: an exception escaping it is fatal on
+        PyQt6 (qFatal → abort), so validation failures must end in a
+        message bar warning, never a raise.
+        """
         working_directory = self.create_project_widget.working_dir or self.tree_widget.working_directory
-        if not working_directory:
+        if not working_directory or not os.path.isdir(working_directory):
             self.message_bar.pushWarning(
                 "Missing working directory",
-                "Open or create a project before setting network layers.",
+                (
+                    "Open or create a project before setting network layers."
+                    if not working_directory
+                    else f"The project folder no longer exists: {working_directory}"
+                ),
             )
             return
-        self.stacked_widget.setCurrentIndex(ROAD_NETWORK_PANEL)
-        self.road_network_widget.set_working_directory(working_directory)
-        if self.create_project_widget.working_dir:
-            self.road_network_widget.set_reference_layer(self.create_project_widget.reference_layer())
-            self.road_network_widget.set_crs(
-                self.create_project_widget.crs(working_directory=self.create_project_widget.working_dir)
-            )
+        try:
+            self.stacked_widget.setCurrentIndex(ROAD_NETWORK_PANEL)
+            self.road_network_widget.set_working_directory(working_directory)
+            if self.create_project_widget.working_dir:
+                self.road_network_widget.set_reference_layer(self.create_project_widget.reference_layer())
+                self.road_network_widget.set_crs(
+                    self.create_project_widget.crs(working_directory=self.create_project_widget.working_dir)
+                )
+        except Exception as e:
+            log_message(f"Failed to open the road network panel: {e}", tag="GeoE3", level=Qgis.Critical)
+            self.message_bar.pushWarning("Road network panel", f"Could not open the road network panel: {e}")
 
     def _open_next_panel_after_project_creation(self) -> None:
         """Open the next panel after project creation based on analysis scale."""

--- a/geest/gui/panels/tree_panel.py
+++ b/geest/gui/panels/tree_panel.py
@@ -6,9 +6,7 @@ This module contains functionality for tree panel.
 
 import json
 import os
-import platform
 import shutil
-import subprocess  # nosec B404
 import traceback
 from functools import partial
 from logging import getLogger
@@ -72,7 +70,7 @@ from geest.gui.dialogs import (
 )
 from geest.gui.views import JsonTreeModel, JsonTreeView
 from geest.gui.widgets import SolidMenu
-from geest.utilities import log_message, resources_path, theme_stylesheet
+from geest.utilities import log_message, open_with_system_handler, resources_path, theme_stylesheet
 
 
 class TreePanel(QWidget):
@@ -422,10 +420,7 @@ class TreePanel(QWidget):
 
         if msg_box.clickedButton() == open_folder_button:
             if self.working_directory:
-                if os.name == "nt":
-                    os.startfile(self.working_directory)  # nosec B606
-                elif os.name == "posix":
-                    subprocess.run(["xdg-open", self.working_directory], check=False)  # nosec B603 B607
+                open_with_system_handler(self.working_directory)
                 return
 
         if reply == QMessageBox.StandardButton.No or reply == QMessageBox.DialogCode.Rejected:
@@ -1211,18 +1206,9 @@ class TreePanel(QWidget):
             report.export_pdf(os.path.join(self.working_directory, "study_area_report.pdf"))
             self.overall_progress_bar.setValue(90)
 
-        # open the pdf using the system PDF viewer
-        # Windows
-        if os.name == "nt":  # Windows
-            os.startfile(os.path.join(self.working_directory, "study_area_report.pdf"))  # nosec B606
-        else:  # macOS and Linux
-            system = platform.system().lower()
-            if system == "darwin":  # macOS
-                pdf_path = os.path.join(self.working_directory, "study_area_report.pdf")
-                subprocess.run(["open", pdf_path], check=False)  # nosec B603 B607
-            else:  # Linux
-                pdf_path = os.path.join(self.working_directory, "study_area_report.pdf")
-                subprocess.run(["xdg-open", pdf_path], check=False)  # nosec B603 B607
+        # Open the pdf using the system PDF viewer (detached — a blocking
+        # call here freezes the QGIS event loop behind the viewer window).
+        open_with_system_handler(os.path.join(self.working_directory, "study_area_report.pdf"))
         self.overall_progress_bar.setValue(100)
         self.overall_progress_bar.setVisible(False)
 
@@ -1405,11 +1391,7 @@ class TreePanel(QWidget):
             )
         log_message(f"Opening working directory: {working_directory}")
         if working_directory:
-            if os.name == "nt":
-                os.startfile(working_directory)  # nosec B606
-            elif os.name == "posix":
-                log_message("Using xdg-open to open the working directory.")
-                subprocess.run(["xdg-open", working_directory], check=False)  # nosec B603 B607
+            open_with_system_handler(working_directory)
         else:
             QMessageBox.warning(self, "No Working Directory", "The working directory is not set.")
 
@@ -1419,10 +1401,7 @@ class TreePanel(QWidget):
         log_file_path = logger.handlers[0].baseFilename
 
         if os.path.exists(log_file_path):
-            if os.name == "nt":
-                os.startfile(log_file_path)  # nosec B606
-            elif os.name == "posix":
-                subprocess.run(["xdg-open", log_file_path], check=False)  # nosec B603 B607
+            open_with_system_handler(log_file_path)
         else:
             QMessageBox.warning(self, "Log File Not Found", "The log file does not exist.")
 

--- a/geest/utilities.py
+++ b/geest/utilities.py
@@ -554,6 +554,33 @@ def linear_interpolation(
     return result
 
 
+def open_with_system_handler(path: str) -> None:
+    """Open a file or folder with the default system application, detached.
+
+    This must never block the calling (QGIS main) thread and must never
+    join the viewer to QGIS's process group: subprocess.run freezes the
+    event loop until the viewer exits, leaving QGIS unresponsive behind
+    the viewer window, and force-closing the viewer then takes QGIS down
+    with it.
+
+    Args:
+        path (str): File or directory to open.
+    """
+    try:
+        if os.name == "nt":  # Windows
+            os.startfile(path)  # nosec B606
+            return
+        opener = "open" if platform.system().lower() == "darwin" else "xdg-open"
+        subprocess.Popen(  # nosec B603 B607
+            [opener, path],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as e:
+        log_message(f"Could not open '{path}' with the system handler: {e}", level=Qgis.Warning)
+
+
 def vector_layer_type(layer: QgsVectorLayer) -> str:
     """
     Determines if a given QgsVectorLayer is a GeoPackage or a Shapefile.

--- a/test/test_geoe3_dock_construction.py
+++ b/test/test_geoe3_dock_construction.py
@@ -26,6 +26,25 @@ class TestGeoE3DockConstruction(unittest.TestCase):
         dock = GeoE3Dock(parent=PARENT, json_file=resources_path("resources", "model.json"))
         self.assertGreater(dock.stacked_widget.count(), 0)
 
+    def test_ors_next_with_stale_working_directory_is_survivable(self):
+        """Next on the ORS panel with a vanished project folder must not raise.
+
+        This slot runs from a Qt signal: on PyQt6 an exception escaping it
+        aborts QGIS (qFatal), so a stale working directory (moved/renamed
+        project folder) has to end in a message-bar warning instead.
+        """
+        dock = GeoE3Dock(parent=PARENT, json_file=resources_path("resources", "model.json"))
+        for stale in ("/no/such/folder", "", None):
+            dock.create_project_widget.working_dir = stale
+            dock.tree_widget.working_directory = ""
+            before = dock.stacked_widget.currentIndex()
+            dock._open_road_network_from_ors()  # must not raise
+            self.assertEqual(
+                dock.stacked_widget.currentIndex(),
+                before,
+                f"panel switched despite invalid working directory {stale!r}",
+            )
+
     def test_dock_area_to_int_portable(self):
         """Enum → int works on PyQt5 sip enums and PyQt6 pure Flags alike."""
         self.assertEqual(_dock_area_to_int(Qt.DockWidgetArea.LeftDockWidgetArea), 1)

--- a/test/test_open_documents.py
+++ b/test/test_open_documents.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Opening documents/folders must never block the QGIS main thread.
+
+subprocess.run(["xdg-open", pdf]) on the main thread freezes the QGIS
+event loop until the viewer exits (the UI appears focus-locked behind the
+viewer), and force-closing the viewer can take the whole process group —
+QGIS included — down with it. Every open-with-system-handler call must go
+through geest.utilities.open_with_system_handler, which launches the
+handler detached in its own session.
+"""
+
+import os
+import re
+import unittest
+from unittest import mock
+
+from geest import utilities
+from geest.utilities import open_with_system_handler
+
+PACKAGE_ROOT = os.path.dirname(os.path.abspath(utilities.__file__))
+
+BLOCKING_OPEN_RE = re.compile(r"subprocess\.run\(\s*\[\s*\"(?:xdg-open|open)\"")
+STARTFILE_RE = re.compile(r"os\.startfile\(")
+
+
+def _python_sources():
+    for root, dirs, files in os.walk(PACKAGE_ROOT):
+        dirs[:] = [d for d in dirs if d not in {"__pycache__", "extlibs"}]
+        for name in files:
+            if name.endswith(".py"):
+                yield os.path.join(root, name)
+
+
+class TestOpenWithSystemHandler(unittest.TestCase):
+    def test_launches_detached_in_new_session(self):
+        """The handler is spawned with Popen in its own session, not run()."""
+        with mock.patch.object(utilities.subprocess, "Popen") as popen:
+            with mock.patch.object(utilities.os, "name", "posix"):
+                open_with_system_handler("/tmp/report.pdf")  # nosec B108
+        popen.assert_called_once()
+        args, kwargs = popen.call_args
+        self.assertIn(args[0][0], ("xdg-open", "open"))
+        self.assertEqual(args[0][1], "/tmp/report.pdf")  # nosec B108
+        self.assertTrue(kwargs.get("start_new_session"), "viewer must not join QGIS's process group")
+
+    def test_never_raises(self):
+        """A failing launcher degrades to a log message, never an exception."""
+        with mock.patch.object(utilities.subprocess, "Popen", side_effect=OSError("no xdg-open")):
+            with mock.patch.object(utilities.os, "name", "posix"):
+                open_with_system_handler("/tmp/report.pdf")  # nosec B108
+
+    def test_no_blocking_open_calls_in_package(self):
+        """No file may open documents with blocking subprocess.run/startfile.
+
+        os.startfile is only legitimate inside utilities.py (it is
+        non-blocking on Windows); subprocess.run with xdg-open/open is
+        never legitimate.
+        """
+        offenders = []
+        for path in _python_sources():
+            with open(path, "r", encoding="utf-8") as handle:
+                source = handle.read()
+            rel = os.path.relpath(path, PACKAGE_ROOT)
+            if BLOCKING_OPEN_RE.search(source):
+                offenders.append(f"{rel}: blocking subprocess.run open call")
+            if rel != "utilities.py" and STARTFILE_RE.search(source):
+                offenders.append(f"{rel}: os.startfile outside utilities.open_with_system_handler")
+        self.assertEqual(offenders, [], "Use geest.utilities.open_with_system_handler:\n" + "\n".join(offenders))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_open_documents.py
+++ b/test/test_open_documents.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Opening documents/folders must never block the QGIS main thread.
 
-subprocess.run(["xdg-open", pdf]) on the main thread freezes the QGIS
+subprocess.run(['xdg-open', pdf]) on the main thread freezes the QGIS
 event loop until the viewer exits (the UI appears focus-locked behind the
 viewer), and force-closing the viewer can take the whole process group —
 QGIS included — down with it. Every open-with-system-handler call must go


### PR DESCRIPTION
Fixes #407
Fixes #408

## What

Two crash/freeze fixes, each with tests, green on both QGIS 3.34 LTR (PyQt5) and QGIS 4.x master (PyQt6) — 220 tests, 0 failures, 0 errors.

### 1. Open reports and folders detached from the QGIS process (#407)

All six document/folder open sites used `subprocess.run(["xdg-open", ...])` on the QGIS main thread:

- the QGIS event loop froze until the viewer exited, so QGIS appeared focus-locked behind the PDF viewer;
- the viewer joined QGIS's process group, so force-closing it took QGIS down with it (signal 11 abort).

Every open now goes through a new `geest.utilities.open_with_system_handler`, which launches the handler with `Popen(..., start_new_session=True)` and never raises. A mechanical test (`test/test_open_documents.py`) walks the package sources and forbids blocking open calls from returning.

### 2. Survive a stale working directory on the routing panel Next (#408)

Pressing Next on the ORS routing panel calls `set_working_directory` on the road network panel, which raises if the project folder has vanished (moved, renamed, or unmounted). The call runs inside a Qt signal slot, and on PyQt6/QGIS 4 an exception escaping a slot is fatal (`qFatal` → signal 11 abort).

The slot now validates the working directory up front and degrades to a message-bar warning; the panel switch is wrapped so no exception can escape. Covered by a survivability test in `test/test_geoe3_dock_construction.py`.

## Testing

```
./scripts/run-docker-tests.sh all
── QGIS 3.34 LTR: PASSED  (GEOE3-SUITE: verdict=PASS run=220 failures=0 errors=0)
── QGIS 4.x master: PASSED (GEOE3-SUITE: verdict=PASS run=220 failures=0 errors=0)
```