### PR TITLE
Check accessibility logic

### DIFF
--- a/geest/core/grid_column_utils.py
+++ b/geest/core/grid_column_utils.py
@@ -1913,6 +1913,193 @@ def write_buffer_values_to_grid(
         return -1
 
 
+def write_percentage_scores_to_grid(
+    gpkg_path: str,
+    column_name: str,
+    buffer_layer: QgsVectorLayer,
+    percentage_scores: Dict[int, int],
+    feedback: QgsFeedback = None,
+) -> int:
+    """Score grid cells by % of hexagon area covered by dissolved POI buffers.
+
+    All buffer polygons are dissolved (unioned) first so that overlapping
+    buffers from nearby POIs are not double-counted.  Each hexagon's score is
+    then determined by what fraction of its own area falls inside the merged
+    buffer, mapped to a 0–5 class via *percentage_scores*.
+
+    Args:
+        gpkg_path: Path to the GeoPackage containing study_area_grid.
+        column_name: Name of the column to write values to.
+        buffer_layer: QgsVectorLayer containing buffer polygons (geometry only).
+        percentage_scores: Mapping of lower-bound percentage → score, e.g.
+            ``{0: 0, 6: 1, 12: 2, 18: 3, 24: 4, 100: 5}``.
+        feedback: Optional feedback for progress reporting.
+
+    Returns:
+        Number of cells updated, or -1 on error.
+    """
+    from qgis.core import (
+        QgsCoordinateTransform,
+        QgsGeometry,
+        QgsProject,
+    )
+
+    if not os.path.exists(gpkg_path):
+        log_message(f"GeoPackage not found: {gpkg_path}", level=Qgis.Warning)
+        return -1
+
+    if not buffer_layer or not buffer_layer.isValid():
+        log_message("Invalid buffer layer provided", level=Qgis.Warning)
+        return -1
+
+    if not percentage_scores:
+        log_message("No percentage_scores provided", level=Qgis.Warning)
+        return -1
+
+    sanitized_column = _sanitize_column_name(column_name)
+    _ensure_column_exists(gpkg_path, sanitized_column)
+
+    try:
+        grid_layer = QgsVectorLayer(f"{gpkg_path}|layername=study_area_grid", "grid", "ogr")
+        if not grid_layer.isValid():
+            log_message("Could not load study_area_grid layer", level=Qgis.Critical)
+            return -1
+
+        transform = None
+        if buffer_layer.crs() != grid_layer.crs():
+            log_message(
+                f"Buffer layer CRS {buffer_layer.crs().authid()} differs from grid CRS "
+                f"{grid_layer.crs().authid()} — reprojecting buffers on the fly",
+                level=Qgis.Warning,
+            )
+            transform = QgsCoordinateTransform(buffer_layer.crs(), grid_layer.crs(), QgsProject.instance())
+
+        buffer_geoms = []
+        repaired = 0
+        for buffer_feature in buffer_layer.getFeatures():
+            geometry = QgsGeometry(buffer_feature.geometry())
+            if geometry.isEmpty():
+                continue
+            if transform is not None:
+                geometry.transform(transform)
+            if not geometry.isGeosValid():
+                geometry = geometry.makeValid()
+                repaired += 1
+                if geometry.isEmpty():
+                    continue
+            buffer_geoms.append(geometry)
+        if repaired:
+            log_message(f"Repaired {repaired} invalid buffer geometries before dissolving")
+
+        if not buffer_geoms:
+            log_message("No valid buffer geometries to dissolve", level=Qgis.Warning)
+            return 0
+
+        dissolved = QgsGeometry.unaryUnion(buffer_geoms)
+        if dissolved.isNull() or dissolved.isEmpty():
+            log_message("Dissolved buffer is empty", level=Qgis.Warning)
+            return 0
+        if not dissolved.isGeosValid():
+            dissolved = dissolved.makeValid()
+
+        log_message(f"Dissolved {len(buffer_geoms)} buffers into unified polygon")
+
+        sorted_thresholds = sorted(percentage_scores.items())
+
+        def _score_for_percent(pct: float) -> int:
+            score = 0
+            for min_pct, s in sorted_thresholds:
+                if pct > min_pct:
+                    score = s
+                else:
+                    break
+            return score
+
+        grid_scores = {}
+        total_features = grid_layer.featureCount()
+        log_message(f"Scoring {total_features} grid cells by percentage intersection")
+        if total_features == 0:
+            log_message(
+                "study_area_grid contains no cells — nothing can be scored.",
+                level=Qgis.Critical,
+            )
+            return -1
+
+        for i, grid_feature in enumerate(grid_layer.getFeatures()):
+            grid_geom = grid_feature.geometry()
+            if grid_geom.isEmpty():
+                continue
+
+            grid_area = grid_geom.area()
+            if grid_area == 0:
+                continue
+
+            intersection = grid_geom.intersection(dissolved)
+            if intersection.isNull() or intersection.area() == 0:
+                continue
+
+            overlap_percent = (intersection.area() / grid_area) * 100
+            score = _score_for_percent(overlap_percent)
+            if score > 0:
+                grid_scores[grid_feature.id()] = score
+
+            if feedback and i % 1000 == 0:
+                feedback.setProgress((i / total_features) * 80)
+
+        log_message(f"Found {len(grid_scores)} grid cells with buffer coverage")
+
+        ds = _open_gpkg_for_write(gpkg_path)
+        if not ds:
+            log_message(f"Could not open GeoPackage: {gpkg_path}", level=Qgis.Critical)
+            return -1
+
+        updated_count = 0
+        batch_size = 500
+        fids = list(grid_scores.keys())
+
+        for batch_start in range(0, len(fids), batch_size):
+            batch_fids = fids[batch_start : batch_start + batch_size]
+
+            case_parts = []
+            for fid in batch_fids:
+                score = grid_scores[fid]
+                case_parts.append(f"WHEN fid = {fid} THEN {score}")
+
+            if case_parts:
+                fid_list = ",".join(str(f) for f in batch_fids)
+                sql = (
+                    f"UPDATE study_area_grid "  # nosec B608
+                    f'SET "{sanitized_column}" = CASE {" ".join(case_parts)} END '
+                    f"WHERE fid IN ({fid_list})"
+                )
+                _execute_sql_with_retry(ds, sql)
+                updated_count += len(batch_fids)
+
+            if feedback:
+                progress = 80 + (batch_start / max(len(fids), 1)) * 20
+                feedback.setProgress(progress)
+
+        ds = None
+        log_message(f"Updated {updated_count} grid cells with percentage-based scores")
+
+        ds = _open_gpkg_for_write(gpkg_path)
+        if ds:
+            sql = (
+                f"UPDATE study_area_grid "  # nosec B608
+                f'SET "{sanitized_column}" = 0 '
+                f'WHERE "{sanitized_column}" IS NULL'
+            )
+            _execute_sql_with_retry(ds, sql)
+            ds = None
+            log_message(f"Set score 0 for cells outside all buffers in column {sanitized_column}")
+
+        return updated_count
+
+    except Exception as e:
+        log_message(f"Error in write_percentage_scores_to_grid: {e}", level=Qgis.Critical)
+        return -1
+
+
 def get_grid_column_statistics(
     gpkg_path: str,
     column_name: str,

--- a/geest/core/grid_column_utils.py
+++ b/geest/core/grid_column_utils.py
@@ -2007,13 +2007,10 @@ def write_percentage_scores_to_grid(
         sorted_thresholds = sorted(percentage_scores.items())
 
         def _score_for_percent(pct: float) -> int:
-            score = 0
-            for min_pct, s in sorted_thresholds:
-                if pct > min_pct:
-                    score = s
-                else:
-                    break
-            return score
+            for max_pct, s in sorted_thresholds:
+                if pct <= max_pct:
+                    return s
+            return sorted_thresholds[-1][1]
 
         grid_scores = {}
         total_features = grid_layer.featureCount()

--- a/geest/core/workflows/multi_buffer_distances_native_workflow.py
+++ b/geest/core/workflows/multi_buffer_distances_native_workflow.py
@@ -31,6 +31,7 @@ from geest.core.grid_column_utils import (
     clear_grid_column,
     rasterize_grid_column,
     write_buffer_values_to_grid,
+    write_percentage_scores_to_grid,
 )
 from geest.core.workflows.mappings import MAPPING_REGISTRY
 from geest.utilities import log_message
@@ -387,14 +388,23 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
 
         # Write buffer scores to grid cells
         log_message(f"Writing buffer scores to grid column {self.layer_id}")
-        write_buffer_values_to_grid(
-            gpkg_path=self.gpkg_path,
-            column_name=self.layer_id,
-            buffer_layer=scored_buffers,
-            value_field="value",
-            aggregation_method="MAX",
-            feedback=self.feedback,
-        )
+        if self.use_simple_buffer and self.buffer_distance:
+            write_percentage_scores_to_grid(
+                gpkg_path=self.gpkg_path,
+                column_name=self.layer_id,
+                buffer_layer=scored_buffers,
+                percentage_scores=self.percentage_scores,
+                feedback=self.feedback,
+            )
+        else:
+            write_buffer_values_to_grid(
+                gpkg_path=self.gpkg_path,
+                column_name=self.layer_id,
+                buffer_layer=scored_buffers,
+                value_field="value",
+                aggregation_method="MAX",
+                feedback=self.feedback,
+            )
 
         self.progressChanged.emit(80.0)
 
@@ -462,17 +472,12 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
             )
             return False
 
-        # Add value field with score 5 (highest accessibility)
+        # Add value field (placeholder — actual scoring happens in
+        # write_percentage_scores_to_grid via percentage intersection)
         field_names = [field.name() for field in buffered_layer.fields()]
         if "value" not in field_names:
             buffered_layer.dataProvider().addAttributes([QgsField("value", QVariant.Int)])
             buffered_layer.updateFields()
-
-        buffered_layer.startEditing()
-        for feature in buffered_layer.getFeatures():
-            feature.setAttribute("value", 5)
-            buffered_layer.updateFeature(feature)
-        buffered_layer.commitChanges()
 
         return buffered_layer
 
@@ -781,6 +786,29 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
         if "value" not in field_names:
             grid_layer.dataProvider().addAttributes([QgsField("value", QVariant.Int)])
             grid_layer.updateFields()
+
+        buffer_geoms = []
+        for buffered_feature in buffered_layer.getFeatures():
+            geom = buffered_feature.geometry()
+            if geom.isNull() or geom.isEmpty():
+                continue
+            if not geom.isGeosValid():
+                geom = geom.makeValid()
+                if geom.isEmpty():
+                    continue
+            buffer_geoms.append(geom)
+
+        dissolved = QgsGeometry.unaryUnion(buffer_geoms) if buffer_geoms else QgsGeometry()
+        if dissolved.isNull() or dissolved.isEmpty():
+            log_message("No valid buffer geometries to dissolve", level=Qgis.Warning)
+            return grid_layer
+        if not dissolved.isGeosValid():
+            dissolved = dissolved.makeValid()
+
+        log_message(f"Dissolved {len(buffer_geoms)} buffers for percentage scoring")
+
+        sorted_thresholds = sorted(self.percentage_scores.items())
+
         grid_layer.startEditing()
         for grid_feature in grid_layer.getFeatures():
             grid_geom = grid_feature.geometry()
@@ -789,64 +817,21 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
             grid_area = grid_geom.area()
             if grid_area == 0:
                 continue
-            max_score = 0
-            max_overlap_percent = 0
-            for buffered_feature in buffered_layer.getFeatures():
-                buffered_geom = buffered_feature.geometry()
-                if buffered_geom.isNull():
-                    continue
-                intersection = grid_geom.intersection(buffered_geom)
-                if intersection.isNull() or intersection.area() == 0:
-                    continue
-                # Calculate % of buffer within hexagon (not % of hexagon covered)
-                buffer_area = buffered_geom.area()
-                if buffer_area > 0:
-                    overlap_percent = (intersection.area() / buffer_area) * 100
+
+            intersection = grid_geom.intersection(dissolved)
+            if intersection.isNull() or intersection.area() == 0:
+                grid_feature.setAttribute("value", 0)
+                grid_layer.updateFeature(grid_feature)
+                continue
+
+            overlap_percent = (intersection.area() / grid_area) * 100
+            score = 0
+            for min_pct, s in sorted_thresholds:
+                if overlap_percent > min_pct:
+                    score = s
                 else:
-                    overlap_percent = 0
-                if overlap_percent > max_overlap_percent:
-                    max_overlap_percent = overlap_percent
-            # Calculate score based on final max_overlap_percent after all buffers checked
-            # Table ranges: Score 0: 0%, Score 1: 0.01-6%, Score 2: 6.01-12%, etc.
-            sorted_items = sorted(self.percentage_scores.items())
-            log_message(
-                f"DEBUG: Feature {grid_feature.id()} - max_overlap: {max_overlap_percent:.4f}%, thresholds: {sorted_items}",
-                level=Qgis.Info,
-            )
-            max_score = 0
-            for i, (min_pct, score) in enumerate(sorted_items):
-                if score == 0:
-                    if max_overlap_percent == 0:
-                        max_score = 0
-                        log_message(
-                            f"DEBUG: Feature {grid_feature.id()} - Score 0 (overlap=0%)",
-                            level=Qgis.Info,
-                        )
-                elif i == len(sorted_items) - 1:
-                    # Last score: prev_pct < overlap (e.g., 24 < x <= 100, but use >= for float precision)
-                    prev_pct = sorted_items[i - 1][0]
-                    in_range = prev_pct < max_overlap_percent
-                    log_message(
-                        f"DEBUG: Feature {grid_feature.id()} - Checking Score {score}: {prev_pct} < {max_overlap_percent:.4f} = {in_range}",
-                        level=Qgis.Info,
-                    )
-                    if in_range:
-                        max_score = score
-                else:
-                    # Middle scores: prev_pct < overlap <= min_pct
-                    prev_pct = sorted_items[i - 1][0]
-                    in_range = prev_pct < max_overlap_percent <= min_pct
-                    log_message(
-                        f"DEBUG: Feature {grid_feature.id()} - Checking Score {score}: {prev_pct} < {max_overlap_percent:.4f} <= {min_pct} = {in_range}",
-                        level=Qgis.Info,
-                    )
-                    if in_range:
-                        max_score = score
-            log_message(
-                f"DEBUG: Feature {grid_feature.id()} - FINAL: max_overlap={max_overlap_percent:.4f}%, assigned_score={max_score}",
-                level=Qgis.Info,
-            )
-            grid_feature.setAttribute("value", max_score)
+                    break
+            grid_feature.setAttribute("value", score)
             grid_layer.updateFeature(grid_feature)
         grid_layer.commitChanges()
         return grid_layer
@@ -977,49 +962,30 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
     def _assign_percentage_scores(self, layer: QgsVectorLayer) -> QgsVectorLayer:
         """Assign scores based on percentage intersection with buffer.
 
-        For Regional scale: calculates what percentage of each grid cell
-        is covered by the accessibility buffer and assigns score accordingly.
+        Note: This method is only reachable from the legacy raster-first path
+        via _assign_scores(). The grid-first path uses
+        write_percentage_scores_to_grid() directly. The legacy Regional path
+        uses _score_grid_for_percentage() instead.
+
+        This method operates on a single buffer layer and cannot compute
+        percentage intersection without a separate grid layer. It assigns
+        score 0 as a safe fallback; percentage scoring requires the
+        grid-first path or _score_grid_for_percentage().
 
         Args:
             layer: The buffered features layer.
 
         Returns:
-            The same layer with a "value" field containing the assigned scores.
+            The same layer with a "value" field set to 0.
         """
-        log_message("Using percentage-based scoring for Regional scale")
-        buffer_distance = 0
-        if hasattr(self, "buffer_distances") and self.buffer_distances:
-            buffer_distance = (
-                max(self.buffer_distances) if isinstance(self.buffer_distances, list) else self.buffer_distances
-            )
-        elif self.distances:
-            buffer_distance = max(self.distances) if isinstance(self.distances, list) else self.distances
-        log_message(f"Buffer distance for percentage scoring: {buffer_distance}m")
+        log_message(
+            "_assign_percentage_scores called on buffer layer without grid context — "
+            "assigning score 0. Use grid-first path for percentage-based scoring.",
+            level=Qgis.Warning,
+        )
         layer.startEditing()
         for feature in layer.getFeatures():
-            grid_geom = feature.geometry()
-            if grid_geom.isNull():
-                continue
-            grid_area = grid_geom.area()
-            buffer_geom = feature.geometry()
-            if buffer_geom.isNull():
-                continue
-            intersection = grid_geom.intersection(buffer_geom)
-            if intersection.isNull() or intersection.area() == 0:
-                feature.setAttribute("value", 0)
-            else:
-                overlap_percent = (intersection.area() / grid_area) * 100
-                score = 0
-                for min_pct, score_value in sorted(self.percentage_scores.items(), reverse=True):
-                    if overlap_percent >= min_pct:
-                        score = score_value
-                        break
-                feature.setAttribute("value", score)
-                log_message(
-                    f"Grid cell overlap: {overlap_percent:.2f}%, score: {score}",
-                    tag="GeoE3",
-                    level=Qgis.Info,
-                )
+            feature.setAttribute("value", 0)
             layer.updateFeature(feature)
         layer.commitChanges()
         return layer

--- a/geest/core/workflows/multi_buffer_distances_native_workflow.py
+++ b/geest/core/workflows/multi_buffer_distances_native_workflow.py
@@ -826,11 +826,12 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
 
             overlap_percent = (intersection.area() / grid_area) * 100
             score = 0
-            for min_pct, s in sorted_thresholds:
-                if overlap_percent > min_pct:
+            for max_pct, s in sorted_thresholds:
+                if overlap_percent <= max_pct:
                     score = s
-                else:
                     break
+            else:
+                score = sorted_thresholds[-1][1]
             grid_feature.setAttribute("value", score)
             grid_layer.updateFeature(grid_feature)
         grid_layer.commitChanges()

--- a/geest/core/workflows/single_point_buffer_workflow.py
+++ b/geest/core/workflows/single_point_buffer_workflow.py
@@ -27,6 +27,7 @@ from geest.core.grid_column_utils import (
     clear_grid_column,
     rasterize_grid_column,
     write_buffer_values_to_grid,
+    write_percentage_scores_to_grid,
 )
 from geest.core.workflows.mappings import MAPPING_REGISTRY
 from geest.utilities import log_message
@@ -193,21 +194,28 @@ class SinglePointBufferWorkflow(WorkflowBase):
 
         self.progressChanged.emit(30.0)
 
-        # Step 2: Assign values to the buffered polygons
-        scored_layer = self._assign_scores(buffered_layer)
-
-        self.progressChanged.emit(40.0)
-
-        # Step 3: Write buffer scores to grid cells
-        log_message(f"Writing buffer scores to grid column {self.layer_id}")
-        write_buffer_values_to_grid(
-            gpkg_path=self.gpkg_path,
-            column_name=self.layer_id,
-            buffer_layer=scored_layer,
-            value_field="value",
-            aggregation_method="MAX",
-            feedback=self.feedback,
-        )
+        if self.scoring_method == "percentage_intersection" and self.percentage_scores:
+            self.progressChanged.emit(40.0)
+            log_message(f"Writing percentage-based scores to grid column {self.layer_id}")
+            write_percentage_scores_to_grid(
+                gpkg_path=self.gpkg_path,
+                column_name=self.layer_id,
+                buffer_layer=buffered_layer,
+                percentage_scores=self.percentage_scores,
+                feedback=self.feedback,
+            )
+        else:
+            scored_layer = self._assign_scores(buffered_layer)
+            self.progressChanged.emit(40.0)
+            log_message(f"Writing buffer scores to grid column {self.layer_id}")
+            write_buffer_values_to_grid(
+                gpkg_path=self.gpkg_path,
+                column_name=self.layer_id,
+                buffer_layer=scored_layer,
+                value_field="value",
+                aggregation_method="MAX",
+                feedback=self.feedback,
+            )
 
         self.progressChanged.emit(70.0)
 
@@ -343,6 +351,29 @@ class SinglePointBufferWorkflow(WorkflowBase):
         if "value" not in field_names:
             grid_layer.dataProvider().addAttributes([QgsField("value", QVariant.Int)])
             grid_layer.updateFields()
+
+        buffer_geoms = []
+        for buffered_feature in buffered_layer.getFeatures():
+            geom = buffered_feature.geometry()
+            if geom.isNull() or geom.isEmpty():
+                continue
+            if not geom.isGeosValid():
+                geom = geom.makeValid()
+                if geom.isEmpty():
+                    continue
+            buffer_geoms.append(geom)
+
+        dissolved = QgsGeometry.unaryUnion(buffer_geoms) if buffer_geoms else QgsGeometry()
+        if dissolved.isNull() or dissolved.isEmpty():
+            log_message("No valid buffer geometries to dissolve", level=Qgis.Warning)
+            return grid_layer
+        if not dissolved.isGeosValid():
+            dissolved = dissolved.makeValid()
+
+        log_message(f"Dissolved {len(buffer_geoms)} buffers for percentage scoring")
+
+        sorted_thresholds = sorted(self.percentage_scores.items())
+
         grid_layer.startEditing()
         for grid_feature in grid_layer.getFeatures():
             grid_geom = grid_feature.geometry()
@@ -351,40 +382,21 @@ class SinglePointBufferWorkflow(WorkflowBase):
             grid_area = grid_geom.area()
             if grid_area == 0:
                 continue
-            max_overlap_percent = 0
-            for buffered_feature in buffered_layer.getFeatures():
-                buffered_geom = buffered_feature.geometry()
-                if buffered_geom.isNull():
-                    continue
-                intersection = grid_geom.intersection(buffered_geom)
-                if intersection.isNull() or intersection.area() == 0:
-                    continue
-                # Calculate % of buffer within hexagon
-                buffer_area = buffered_geom.area()
-                if buffer_area > 0:
-                    overlap_percent = (intersection.area() / buffer_area) * 100
+
+            intersection = grid_geom.intersection(dissolved)
+            if intersection.isNull() or intersection.area() == 0:
+                grid_feature.setAttribute("value", 0)
+                grid_layer.updateFeature(grid_feature)
+                continue
+
+            overlap_percent = (intersection.area() / grid_area) * 100
+            score = 0
+            for min_pct, s in sorted_thresholds:
+                if overlap_percent > min_pct:
+                    score = s
                 else:
-                    overlap_percent = 0
-                if overlap_percent > max_overlap_percent:
-                    max_overlap_percent = overlap_percent
-            # Calculate score based on final max_overlap_percent after all buffers checked
-            sorted_items = sorted(self.percentage_scores.items())
-            max_score = 0
-            for i, (min_pct, score) in enumerate(sorted_items):
-                if score == 0:
-                    if max_overlap_percent == 0:
-                        max_score = 0
-                elif i == len(sorted_items) - 1:
-                    # Last score: prev_pct < overlap
-                    prev_pct = sorted_items[i - 1][0]
-                    if prev_pct < max_overlap_percent:
-                        max_score = score
-                else:
-                    # Middle scores: prev_pct < overlap <= min_pct
-                    prev_pct = sorted_items[i - 1][0]
-                    if prev_pct < max_overlap_percent <= min_pct:
-                        max_score = score
-            grid_feature.setAttribute("value", max_score)
+                    break
+            grid_feature.setAttribute("value", score)
             grid_layer.updateFeature(grid_feature)
         grid_layer.commitChanges()
         return grid_layer

--- a/geest/core/workflows/single_point_buffer_workflow.py
+++ b/geest/core/workflows/single_point_buffer_workflow.py
@@ -27,7 +27,6 @@ from geest.core.grid_column_utils import (
     clear_grid_column,
     rasterize_grid_column,
     write_buffer_values_to_grid,
-    write_percentage_scores_to_grid,
 )
 from geest.core.workflows.mappings import MAPPING_REGISTRY
 from geest.utilities import log_message
@@ -194,28 +193,21 @@ class SinglePointBufferWorkflow(WorkflowBase):
 
         self.progressChanged.emit(30.0)
 
-        if self.scoring_method == "percentage_intersection" and self.percentage_scores:
-            self.progressChanged.emit(40.0)
-            log_message(f"Writing percentage-based scores to grid column {self.layer_id}")
-            write_percentage_scores_to_grid(
-                gpkg_path=self.gpkg_path,
-                column_name=self.layer_id,
-                buffer_layer=buffered_layer,
-                percentage_scores=self.percentage_scores,
-                feedback=self.feedback,
-            )
-        else:
-            scored_layer = self._assign_scores(buffered_layer)
-            self.progressChanged.emit(40.0)
-            log_message(f"Writing buffer scores to grid column {self.layer_id}")
-            write_buffer_values_to_grid(
-                gpkg_path=self.gpkg_path,
-                column_name=self.layer_id,
-                buffer_layer=scored_layer,
-                value_field="value",
-                aggregation_method="MAX",
-                feedback=self.feedback,
-            )
+        # Step 2: Assign values to the buffered polygons
+        scored_layer = self._assign_scores(buffered_layer)
+
+        self.progressChanged.emit(40.0)
+
+        # Step 3: Write buffer scores to grid cells
+        log_message(f"Writing buffer scores to grid column {self.layer_id}")
+        write_buffer_values_to_grid(
+            gpkg_path=self.gpkg_path,
+            column_name=self.layer_id,
+            buffer_layer=scored_layer,
+            value_field="value",
+            aggregation_method="MAX",
+            feedback=self.feedback,
+        )
 
         self.progressChanged.emit(70.0)
 
@@ -351,29 +343,6 @@ class SinglePointBufferWorkflow(WorkflowBase):
         if "value" not in field_names:
             grid_layer.dataProvider().addAttributes([QgsField("value", QVariant.Int)])
             grid_layer.updateFields()
-
-        buffer_geoms = []
-        for buffered_feature in buffered_layer.getFeatures():
-            geom = buffered_feature.geometry()
-            if geom.isNull() or geom.isEmpty():
-                continue
-            if not geom.isGeosValid():
-                geom = geom.makeValid()
-                if geom.isEmpty():
-                    continue
-            buffer_geoms.append(geom)
-
-        dissolved = QgsGeometry.unaryUnion(buffer_geoms) if buffer_geoms else QgsGeometry()
-        if dissolved.isNull() or dissolved.isEmpty():
-            log_message("No valid buffer geometries to dissolve", level=Qgis.Warning)
-            return grid_layer
-        if not dissolved.isGeosValid():
-            dissolved = dissolved.makeValid()
-
-        log_message(f"Dissolved {len(buffer_geoms)} buffers for percentage scoring")
-
-        sorted_thresholds = sorted(self.percentage_scores.items())
-
         grid_layer.startEditing()
         for grid_feature in grid_layer.getFeatures():
             grid_geom = grid_feature.geometry()
@@ -382,21 +351,40 @@ class SinglePointBufferWorkflow(WorkflowBase):
             grid_area = grid_geom.area()
             if grid_area == 0:
                 continue
-
-            intersection = grid_geom.intersection(dissolved)
-            if intersection.isNull() or intersection.area() == 0:
-                grid_feature.setAttribute("value", 0)
-                grid_layer.updateFeature(grid_feature)
-                continue
-
-            overlap_percent = (intersection.area() / grid_area) * 100
-            score = 0
-            for min_pct, s in sorted_thresholds:
-                if overlap_percent > min_pct:
-                    score = s
+            max_overlap_percent = 0
+            for buffered_feature in buffered_layer.getFeatures():
+                buffered_geom = buffered_feature.geometry()
+                if buffered_geom.isNull():
+                    continue
+                intersection = grid_geom.intersection(buffered_geom)
+                if intersection.isNull() or intersection.area() == 0:
+                    continue
+                # Calculate % of buffer within hexagon
+                buffer_area = buffered_geom.area()
+                if buffer_area > 0:
+                    overlap_percent = (intersection.area() / buffer_area) * 100
                 else:
-                    break
-            grid_feature.setAttribute("value", score)
+                    overlap_percent = 0
+                if overlap_percent > max_overlap_percent:
+                    max_overlap_percent = overlap_percent
+            # Calculate score based on final max_overlap_percent after all buffers checked
+            sorted_items = sorted(self.percentage_scores.items())
+            max_score = 0
+            for i, (min_pct, score) in enumerate(sorted_items):
+                if score == 0:
+                    if max_overlap_percent == 0:
+                        max_score = 0
+                elif i == len(sorted_items) - 1:
+                    # Last score: prev_pct < overlap
+                    prev_pct = sorted_items[i - 1][0]
+                    if prev_pct < max_overlap_percent:
+                        max_score = score
+                else:
+                    # Middle scores: prev_pct < overlap <= min_pct
+                    prev_pct = sorted_items[i - 1][0]
+                    if prev_pct < max_overlap_percent <= min_pct:
+                        max_score = score
+            grid_feature.setAttribute("value", max_score)
             grid_layer.updateFeature(grid_feature)
         grid_layer.commitChanges()
         return grid_layer


### PR DESCRIPTION
Fixes #411

Previously, any hexagon that overlapped with a POI buffer got the maximum score (5), regardless of how much of the hexagon was actually covered. Now, all POI buffers are merged into one shape, and each hexagon is scored based on what percentage of its own area falls inside that merged buffer. This produces a gradient of scores (0–5) instead of everything being the same colour.

| Indicator | Buffer | Score 1 | Score 2 | Score 3 | Score 4 | Score 5 |
|---|---|---|---|---|---|---|
| WTP | 1.5 km | 0.01–6% | 6.01–12% | 12.01–18% | 18.01–24% | 24.01–100% |
| Public Transport | 1 km | 0.01–6% | 6.01–12% | 12.01–18% | 18.01–24% | 24.01–100% |
| Health Facilities | 6 km | 0.01–20% | 20.01–40% | 40.01–60% | 60.01–80% | 80.01–100% |
| Education | 3 km | 0.01–16% | 16.01–32% | 32.01–48% | 48.01–64% | 64.01–100% |
| Financial | 2.5 km | 0.01–10% | 10.01–20% | 20.01–30% | 30.01–40% | 40.01–100% |
Hexagons with no buffer intersection receive score 0.

<img width="1920" height="714" alt="image" src="https://github.com/user-attachments/assets/755a32fa-cf30-4951-affe-5e9cd77a4324" />